### PR TITLE
Add segment and marque count RPCs

### DIFF
--- a/frontend/src/lib/supabaseClient.js
+++ b/frontend/src/lib/supabaseClient.js
@@ -244,43 +244,24 @@ export const mappingApi = {
     return [...new Set(data.map(item => item.fssfa))].sort((a, b) => a - b);
   },
 
-  // Get total count of unique segments (for statistics) - REAL DATABASE TOTALS
+  // Get total count of unique segments using SQL function
   async getTotalSegmentsCount() {
-    console.log('🔍 [getTotalSegmentsCount] Starting query...');
-    
-    // Query all segments and count unique values
-    const { data, error } = await supabase
-      .from('brand_category_mappings')
-      .select('segment')
-      .order('segment');
-    
-    if (error) {
-      console.error('❌ [getTotalSegmentsCount] Query Error:', error);
-      throw error;
-    }
-    
-    const uniqueCount = [...new Set(data.map(item => item.segment))].length;
-    console.log('✅ [getTotalSegmentsCount] Query result:', uniqueCount);
-    return uniqueCount;
+    const { data, error } = await supabase.rpc('get_total_segments_count');
+    if (error) throw error;
+    return data;
   },
 
-  // Get total count of unique marques (for statistics) - REAL DATABASE TOTALS  
+  // Get total count of unique marques using SQL function
   async getTotalMarquesCount() {
-    console.log('🔍 [getTotalMarquesCount] Starting query...');
-    
-    // Query all marques and count unique values
-    const { data, error } = await supabase
-      .from('brand_category_mappings')
-      .select('marque')
-      .order('marque');
-    
-    if (error) {
-      console.error('❌ [getTotalMarquesCount] Query Error:', error);
-      throw error;
-    }
-    
-    const uniqueCount = [...new Set(data.map(item => item.marque))].length;
-    console.log('✅ [getTotalMarquesCount] Query result:', uniqueCount);
-    return uniqueCount;
+    const { data, error } = await supabase.rpc('get_total_marques_count');
+    if (error) throw error;
+    return data;
+  },
+
+  // Get total count of strategiques using SQL function
+  async getTotalStrategiquesCount() {
+    const { data, error } = await supabase.rpc('get_total_strategiques_count');
+    if (error) throw error;
+    return data;
   }
 };

--- a/frontend/src/pages/Mapping.tsx
+++ b/frontend/src/pages/Mapping.tsx
@@ -77,6 +77,7 @@ export const Mapping: React.FC = () => {
   // Total counts for dashboard (unfiltered)
   const [totalSegments, setTotalSegments] = useState(0);
   const [totalMarques, setTotalMarques] = useState(0);
+  const [totalStrategiques, setTotalStrategiques] = useState(0);
 
   // Charger les données
   const fetchData = async () => {
@@ -103,7 +104,7 @@ export const Mapping: React.FC = () => {
         ...(selectedStrategiq !== 'all' && { strategiq: parseInt(selectedStrategiq) })
       };
       
-      const [mappingsResult, allSegmentsData, allMarquesData, allFsmegasData, allFsfamsData, allFssfasData, totalSegmentsCount, totalMarquesCount] = await Promise.all([
+      const [mappingsResult, allSegmentsData, allMarquesData, allFsmegasData, allFsfamsData, allFssfasData, totalSegmentsCount, totalMarquesCount, totalStrategiquesCount] = await Promise.all([
         mappingApi.getMappings(filters, currentPage, itemsPerPage),
         mappingApi.getAllUniqueSegments(),
         mappingApi.getAllUniqueMarques(),
@@ -111,7 +112,8 @@ export const Mapping: React.FC = () => {
         mappingApi.getAllUniqueFsfams(),
         mappingApi.getAllUniqueFssfas(),
         mappingApi.getTotalSegmentsCount(),
-        mappingApi.getTotalMarquesCount()
+        mappingApi.getTotalMarquesCount(),
+        mappingApi.getTotalStrategiquesCount()
       ]);
       
       console.log('📊 API Results:');
@@ -119,6 +121,7 @@ export const Mapping: React.FC = () => {
       console.log('- mappingsResult.count:', mappingsResult.count);
       console.log('- totalSegmentsCount:', totalSegmentsCount);
       console.log('- totalMarquesCount:', totalMarquesCount);
+      console.log('- totalStrategiquesCount:', totalStrategiquesCount);
       console.log('- allSegmentsData.length:', allSegmentsData.length);
       console.log('- allMarquesData.length:', allMarquesData.length);
       
@@ -129,10 +132,11 @@ export const Mapping: React.FC = () => {
       setFsmegas(allFsmegasData);
       setFsfams(allFsfamsData);
       setFssfas(allFssfasData);
-      
+
       // Set total counts for dashboard (real database totals)
       setTotalSegments(totalSegmentsCount);
       setTotalMarques(totalMarquesCount);
+      setTotalStrategiques(totalStrategiquesCount);
       
       console.log('✅ State updated with totals:');
       console.log('  - totalSegments (should be 7556):', totalSegmentsCount);
@@ -472,9 +476,7 @@ export const Mapping: React.FC = () => {
               </div>
               <div>
                 <p className="text-sm text-gray-600">Stratégiques</p>
-                <p className="text-xl font-bold text-gray-900">
-                  {mappings.filter(m => m.strategiq === 1).length}
-                </p>
+                <p className="text-xl font-bold text-gray-900">{totalStrategiques}</p>
               </div>
             </div>
           </CardContent>

--- a/supabase/migrations/20250722060000_total_counts.sql
+++ b/supabase/migrations/20250722060000_total_counts.sql
@@ -1,0 +1,18 @@
+/*
+  # Add SQL functions for statistics counts
+*/
+
+CREATE OR REPLACE FUNCTION public.get_total_segments_count()
+RETURNS bigint LANGUAGE sql AS $$
+  SELECT COUNT(DISTINCT segment) FROM brand_category_mappings;
+$$;
+
+CREATE OR REPLACE FUNCTION public.get_total_marques_count()
+RETURNS bigint LANGUAGE sql AS $$
+  SELECT COUNT(DISTINCT marque) FROM brand_category_mappings;
+$$;
+
+CREATE OR REPLACE FUNCTION public.get_total_strategiques_count()
+RETURNS bigint LANGUAGE sql AS $$
+  SELECT COUNT(*) FROM brand_category_mappings WHERE strategiq = 1;
+$$;


### PR DESCRIPTION
## Summary
- add SQL RPC functions for counting unique segments, marques, and strategiques
- expose RPCs in `supabaseClient.js`
- fetch counts in `Mapping.tsx` and show them in stats cards

## Testing
- `npm run lint` *(fails: Invalid option `--ext`)*

------
https://chatgpt.com/codex/tasks/task_e_687fa700234c8321ad949b2576b83b58