### PR TITLE
Use includes for mapping filter search

### DIFF
--- a/frontend/src/pages/Mapping.tsx
+++ b/frontend/src/pages/Mapping.tsx
@@ -166,36 +166,36 @@ export const Mapping: React.FC = () => {
   // Filter functions for autocomplete
   const getFilteredSegments = () => {
     if (!segmentSearch) return segments;
-    return segments.filter(segment => 
-      segment.toLowerCase().startsWith(segmentSearch.toLowerCase())
+    return segments.filter(segment =>
+      segment.toLowerCase().includes(segmentSearch.toLowerCase())
     );
   };
 
   const getFilteredMarques = () => {
     if (!marqueSearch) return marques;
-    return marques.filter(marque => 
-      marque.toLowerCase().startsWith(marqueSearch.toLowerCase())
+    return marques.filter(marque =>
+      marque.toLowerCase().includes(marqueSearch.toLowerCase())
     );
   };
 
   const getFilteredFsmegas = () => {
     if (!fsmegaSearch) return fsmegas;
-    return fsmegas.filter(fsmega => 
-      fsmega.toString().startsWith(fsmegaSearch)
+    return fsmegas.filter(fsmega =>
+      fsmega.toString().includes(fsmegaSearch)
     );
   };
 
   const getFilteredFsfams = () => {
     if (!fsfamSearch) return fsfams;
-    return fsfams.filter(fsfam => 
-      fsfam.toString().startsWith(fsfamSearch)
+    return fsfams.filter(fsfam =>
+      fsfam.toString().includes(fsfamSearch)
     );
   };
 
   const getFilteredFssfas = () => {
     if (!fssfaSearch) return fssfas;
-    return fssfas.filter(fssfa => 
-      fssfa.toString().startsWith(fssfaSearch)
+    return fssfas.filter(fssfa =>
+      fssfa.toString().includes(fssfaSearch)
     );
   };
 


### PR DESCRIPTION
## Summary
- make search filters match anywhere in Mapping page

## Testing
- `npm run build` *(fails: TS errors in sidebar.tsx)*
- `npm run lint` in `frontend` *(fails: invalid option '--ext')*

------
https://chatgpt.com/codex/tasks/task_e_687fa7026d60832197e8c369cd00db74