### PR TITLE
Add useEffect hooks for filter search syncing

### DIFF
--- a/frontend/src/pages/Mapping.tsx
+++ b/frontend/src/pages/Mapping.tsx
@@ -160,6 +160,14 @@ export const Mapping: React.FC = () => {
   }, [selectedSegment, selectedMarque, searchTerm, itemsPerPage, selectedFsmega, selectedFsfam, selectedFssfa, selectedStrategiq]);
 
   useEffect(() => {
+    setSegmentSearch(selectedSegment === 'all' ? '' : selectedSegment);
+  }, [selectedSegment]);
+
+  useEffect(() => {
+    setMarqueSearch(selectedMarque === 'all' ? '' : selectedMarque);
+  }, [selectedMarque]);
+
+  useEffect(() => {
     fetchData();
   }, [selectedSegment, selectedMarque, searchTerm, currentPage, itemsPerPage, selectedFsmega, selectedFsfam, selectedFssfa, selectedStrategiq]);
 


### PR DESCRIPTION
## Summary
- keep segment and marque search fields synced with selected filters

## Testing
- `npm run lint --prefix frontend` *(fails: Invalid option '--ext')*
- `npm test --prefix frontend` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687fa70404ec832197a0c656dc5e4b3a