### PR TITLE
Add RPC functions for total counts

### DIFF
--- a/frontend/src/lib/supabaseClient.js
+++ b/frontend/src/lib/supabaseClient.js
@@ -237,53 +237,24 @@ export const mappingApi = {
     return [...new Set(data.map(item => item.fssfa))].sort((a, b) => a - b);
   },
 
-  // Get total count of unique segments using SQL function
+  // Get total count of unique segments via RPC
   async getTotalSegmentsCount() {
-    
-    // Query all segments and count unique values
-    const { data, error } = await supabase
-      .from('brand_category_mappings')
-      .select('segment')
-      .order('segment');
-    
-    if (error) {
-      console.error('❌ [getTotalSegmentsCount] Query Error:', error);
-      throw error;
-    }
-    
-    const uniqueCount = [...new Set(data.map(item => item.segment))].length;
-    return uniqueCount;
+    const { data, error } = await supabase.rpc('get_total_segments_count');
+    if (error) throw error;
+    return data;
   },
 
-  // Get total count of unique marques using SQL function
+  // Get total count of unique marques via RPC
   async getTotalMarquesCount() {
-    
-    // Query all marques and count unique values
-    const { data, error } = await supabase
-      .from('brand_category_mappings')
-      .select('marque')
-      .order('marque');
-    
-    if (error) {
-      console.error('❌ [getTotalMarquesCount] Query Error:', error);
-      throw error;
-    }
-    
-    const uniqueCount = [...new Set(data.map(item => item.marque))].length;
-    return uniqueCount;
+    const { data, error } = await supabase.rpc('get_total_marques_count');
+    if (error) throw error;
+    return data;
   },
 
   // Get total count of strategic mappings via RPC
   async getTotalStrategiquesCount() {
-    console.log('🔍 [getTotalStrategiquesCount] Starting query...');
     const { data, error } = await supabase.rpc('get_total_strategiques_count');
-
-    if (error) {
-      console.error('❌ [getTotalStrategiquesCount] Query Error:', error);
-      throw error;
-    }
-
-    console.log('✅ [getTotalStrategiquesCount] Query result:', data);
+    if (error) throw error;
     return data;
   }
 };

--- a/supabase/migrations/20250722153506_total_counts.sql
+++ b/supabase/migrations/20250722153506_total_counts.sql
@@ -1,0 +1,17 @@
+-- SQL functions to return total counts for segments, marques, and strategiques
+
+CREATE OR REPLACE FUNCTION public.get_total_segments_count()
+RETURNS bigint LANGUAGE sql AS $$
+  SELECT COUNT(DISTINCT segment) FROM brand_category_mappings;
+$$;
+
+CREATE OR REPLACE FUNCTION public.get_total_marques_count()
+RETURNS bigint LANGUAGE sql AS $$
+  SELECT COUNT(DISTINCT marque) FROM brand_category_mappings;
+$$;
+
+CREATE OR REPLACE FUNCTION public.get_total_strategiques_count()
+RETURNS bigint LANGUAGE sql AS $$
+  SELECT COUNT(*) FROM brand_category_mappings WHERE strategiq = 1;
+$$;
+


### PR DESCRIPTION
## Summary
- add SQL RPC functions for counting segments, marques and strategiques
- call the RPC functions in the Supabase client

## Testing
- `npm run lint` *(fails: Invalid option '--ext')*
- `npm run build` *(fails: TS errors in sidebar)*
- `npx supabase db push` *(fails: Cannot find project ref)*

------
https://chatgpt.com/codex/tasks/task_e_687faeeebc8483218715ef85601a1f43