### PR TITLE
Add helper RPCs and update client usage

### DIFF
--- a/frontend/src/lib/supabaseClient.js
+++ b/frontend/src/lib/supabaseClient.js
@@ -140,13 +140,10 @@ export const mappingApi = {
 
   // Get ALL unique segments (no filters applied)
   async getAllUniqueSegments() {
-    const { data, error } = await supabase
-      .from('brand_category_mappings')
-      .select('segment')
-      .order('segment');
-    
+    const { data, error } = await supabase.rpc('get_all_unique_segments');
+
     if (error) throw error;
-    return [...new Set(data.map(item => item.segment))].sort();
+    return data || [];
   },
 
   // Get unique marques for filter
@@ -162,13 +159,10 @@ export const mappingApi = {
 
   // Get ALL unique marques (no filters applied)
   async getAllUniqueMarques() {
-    const { data, error } = await supabase
-      .from('brand_category_mappings')
-      .select('marque')
-      .order('marque');
-    
+    const { data, error } = await supabase.rpc('get_all_unique_marques');
+
     if (error) throw error;
-    return [...new Set(data.map(item => item.marque))].sort();
+    return data || [];
   },
 
   // Get unique FSMEGA values for filter
@@ -184,13 +178,10 @@ export const mappingApi = {
 
   // Get ALL unique FSMEGA values (no filters applied)
   async getAllUniqueFsmegas() {
-    const { data, error } = await supabase
-      .from('brand_category_mappings')
-      .select('fsmega')
-      .order('fsmega');
-    
+    const { data, error } = await supabase.rpc('get_all_unique_fsmegas');
+
     if (error) throw error;
-    return [...new Set(data.map(item => item.fsmega))].sort((a, b) => a - b);
+    return data || [];
   },
 
   // Get unique FSFAM values for filter
@@ -206,13 +197,10 @@ export const mappingApi = {
 
   // Get ALL unique FSFAM values (no filters applied)
   async getAllUniqueFsfams() {
-    const { data, error } = await supabase
-      .from('brand_category_mappings')
-      .select('fsfam')
-      .order('fsfam');
-    
+    const { data, error } = await supabase.rpc('get_all_unique_fsfams');
+
     if (error) throw error;
-    return [...new Set(data.map(item => item.fsfam))].sort((a, b) => a - b);
+    return data || [];
   },
 
   // Get unique FSSFA values for filter
@@ -228,13 +216,10 @@ export const mappingApi = {
 
   // Get ALL unique FSSFA values (no filters applied)
   async getAllUniqueFssfas() {
-    const { data, error } = await supabase
-      .from('brand_category_mappings')
-      .select('fssfa')
-      .order('fssfa');
-    
+    const { data, error } = await supabase.rpc('get_all_unique_fssfas');
+
     if (error) throw error;
-    return [...new Set(data.map(item => item.fssfa))].sort((a, b) => a - b);
+    return data || [];
   },
 
   // Get total count of unique segments using SQL function

--- a/supabase/migrations/20250722060000_shiny_rpcs.sql
+++ b/supabase/migrations/20250722060000_shiny_rpcs.sql
@@ -1,0 +1,55 @@
+/*
+  # Add RPCs for fetching unique classification values
+
+  1. New helper functions
+    - get_all_unique_segments()
+    - get_all_unique_marques()
+    - get_all_unique_fsmegas()
+    - get_all_unique_fsfams()
+    - get_all_unique_fssfas()
+*/
+
+CREATE OR REPLACE FUNCTION public.get_all_unique_segments()
+RETURNS text[] LANGUAGE sql AS $$
+  SELECT ARRAY(
+    SELECT DISTINCT segment
+    FROM brand_category_mappings
+    ORDER BY segment
+  );
+$$;
+
+CREATE OR REPLACE FUNCTION public.get_all_unique_marques()
+RETURNS text[] LANGUAGE sql AS $$
+  SELECT ARRAY(
+    SELECT DISTINCT marque
+    FROM brand_category_mappings
+    ORDER BY marque
+  );
+$$;
+
+CREATE OR REPLACE FUNCTION public.get_all_unique_fsmegas()
+RETURNS integer[] LANGUAGE sql AS $$
+  SELECT ARRAY(
+    SELECT DISTINCT fsmega
+    FROM brand_category_mappings
+    ORDER BY fsmega
+  );
+$$;
+
+CREATE OR REPLACE FUNCTION public.get_all_unique_fsfams()
+RETURNS integer[] LANGUAGE sql AS $$
+  SELECT ARRAY(
+    SELECT DISTINCT fsfam
+    FROM brand_category_mappings
+    ORDER BY fsfam
+  );
+$$;
+
+CREATE OR REPLACE FUNCTION public.get_all_unique_fssfas()
+RETURNS integer[] LANGUAGE sql AS $$
+  SELECT ARRAY(
+    SELECT DISTINCT fssfa
+    FROM brand_category_mappings
+    ORDER BY fssfa
+  );
+$$;


### PR DESCRIPTION
## Summary
- add SQL helpers returning unique classification values
- switch frontend helpers to use new RPC endpoints
- remove local deduplication logic

## Testing
- `npm run lint --prefix frontend` *(fails: Invalid option `--ext`)*
- `npm run build --prefix frontend` *(fails: TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_687faf024b348321abcaa0e8bb3232dd