### PR TITLE
Remove console logs from mapping API

### DIFF
--- a/frontend/src/lib/supabaseClient.js
+++ b/frontend/src/lib/supabaseClient.js
@@ -275,7 +275,6 @@ export const mappingApi = {
 
   // Get total count of strategic mappings via RPC
   async getTotalStrategiquesCount() {
-    console.log('🔍 [getTotalStrategiquesCount] Starting query...');
     const { data, error } = await supabase.rpc('get_total_strategiques_count');
 
     if (error) {
@@ -283,7 +282,6 @@ export const mappingApi = {
       throw error;
     }
 
-    console.log('✅ [getTotalStrategiquesCount] Query result:', data);
     return data;
   }
 };


### PR DESCRIPTION
## Summary
- eliminate console.log statements in `getTotalStrategiquesCount`

## Testing
- `npm run lint --prefix frontend` *(fails: Invalid option `--ext`)*

------
https://chatgpt.com/codex/tasks/task_e_687faf0857ec8321b4653d812c0e0c70