### PR TITLE
Move total counts migration

### DIFF
--- a/supabase/migrations/20250722060000_total_counts.sql
+++ b/supabase/migrations/20250722060000_total_counts.sql
@@ -1,0 +1,18 @@
+/*
+  # Add SQL functions for statistics counts
+*/
+
+CREATE OR REPLACE FUNCTION public.get_total_segments_count()
+RETURNS bigint LANGUAGE sql AS $$
+  SELECT COUNT(DISTINCT segment) FROM brand_category_mappings;
+$$;
+
+CREATE OR REPLACE FUNCTION public.get_total_marques_count()
+RETURNS bigint LANGUAGE sql AS $$
+  SELECT COUNT(DISTINCT marque) FROM brand_category_mappings;
+$$;
+
+CREATE OR REPLACE FUNCTION public.get_total_strategiques_count()
+RETURNS bigint LANGUAGE sql AS $$
+  SELECT COUNT(*) FROM brand_category_mappings WHERE strategiq = 1;
+$$;


### PR DESCRIPTION
## Summary
- restore SQL functions for total count stats into migrations

## Testing
- `npm run lint --prefix frontend` *(fails: Invalid option '--ext')*

------
https://chatgpt.com/codex/tasks/task_e_687faf15f62083218d5695688ef8be49