### PR TITLE
Fix strategic count on mapping page

### DIFF
--- a/frontend/src/pages/Mapping.tsx
+++ b/frontend/src/pages/Mapping.tsx
@@ -114,13 +114,14 @@ export const Mapping: React.FC = () => {
       setFsfams(allFsfamsData);
       setFssfas(allFssfasData);
 
-      // Set total counts for dashboard (real database totals)
-      setTotalSegments(totalSegmentsCount);
-      setTotalMarques(totalMarquesCount);
-    } catch (error) {
-      console.error('❌ Error in fetchData:', error);
-      console.error('Erreur chargement mappings:', error);
-      toast.error('Erreur lors du chargement des mappings');
+        // Set total counts for dashboard (real database totals)
+        setTotalSegments(totalSegmentsCount);
+        setTotalMarques(totalMarquesCount);
+        setTotalStrategiques(totalStrategiquesCount);
+      } catch (error) {
+        console.error('❌ Error in fetchData:', error);
+        console.error('Erreur chargement mappings:', error);
+        toast.error('Erreur lors du chargement des mappings');
     } finally {
       setLoading(false);
     }


### PR DESCRIPTION
## Summary
- update dashboard counts so "Stratégiques" reflects real totals

## Testing
- `npm run lint` *(fails: Invalid option '--ext')*
- `npm run type-check` *(fails: TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68808baaf7a48321a69e51e704d7fdfc