### PR TITLE
Add missing migration functions

### DIFF
--- a/supabase/migrations/20250722060000_shiny_rpcs.sql
+++ b/supabase/migrations/20250722060000_shiny_rpcs.sql
@@ -1,0 +1,55 @@
+/*
+  # Add RPCs for fetching unique classification values
+
+  1. New helper functions
+    - get_all_unique_segments()
+    - get_all_unique_marques()
+    - get_all_unique_fsmegas()
+    - get_all_unique_fsfams()
+    - get_all_unique_fssfas()
+*/
+
+CREATE OR REPLACE FUNCTION public.get_all_unique_segments()
+RETURNS text[] LANGUAGE sql AS $$
+  SELECT ARRAY(
+    SELECT DISTINCT segment
+    FROM brand_category_mappings
+    ORDER BY segment
+  );
+$$;
+
+CREATE OR REPLACE FUNCTION public.get_all_unique_marques()
+RETURNS text[] LANGUAGE sql AS $$
+  SELECT ARRAY(
+    SELECT DISTINCT marque
+    FROM brand_category_mappings
+    ORDER BY marque
+  );
+$$;
+
+CREATE OR REPLACE FUNCTION public.get_all_unique_fsmegas()
+RETURNS integer[] LANGUAGE sql AS $$
+  SELECT ARRAY(
+    SELECT DISTINCT fsmega
+    FROM brand_category_mappings
+    ORDER BY fsmega
+  );
+$$;
+
+CREATE OR REPLACE FUNCTION public.get_all_unique_fsfams()
+RETURNS integer[] LANGUAGE sql AS $$
+  SELECT ARRAY(
+    SELECT DISTINCT fsfam
+    FROM brand_category_mappings
+    ORDER BY fsfam
+  );
+$$;
+
+CREATE OR REPLACE FUNCTION public.get_all_unique_fssfas()
+RETURNS integer[] LANGUAGE sql AS $$
+  SELECT ARRAY(
+    SELECT DISTINCT fssfa
+    FROM brand_category_mappings
+    ORDER BY fssfa
+  );
+$$;

--- a/supabase/migrations/20250722060000_total_counts.sql
+++ b/supabase/migrations/20250722060000_total_counts.sql
@@ -1,0 +1,18 @@
+/*
+  # Add SQL functions for statistics counts
+*/
+
+CREATE OR REPLACE FUNCTION public.get_total_segments_count()
+RETURNS bigint LANGUAGE sql AS $$
+  SELECT COUNT(DISTINCT segment) FROM brand_category_mappings;
+$$;
+
+CREATE OR REPLACE FUNCTION public.get_total_marques_count()
+RETURNS bigint LANGUAGE sql AS $$
+  SELECT COUNT(DISTINCT marque) FROM brand_category_mappings;
+$$;
+
+CREATE OR REPLACE FUNCTION public.get_total_strategiques_count()
+RETURNS bigint LANGUAGE sql AS $$
+  SELECT COUNT(*) FROM brand_category_mappings WHERE strategiq = 1;
+$$;


### PR DESCRIPTION
## Summary
- add migration for total_counts functions
- add migration for shiny RPC helper functions

## Testing
- `npm run lint` *(fails: Invalid option `--ext`)*
- `npm run type-check` *(fails: TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68808bb9557c83218eec352408135540