### PR TITLE
Remove console.error from Supabase client

### DIFF
--- a/frontend/src/lib/supabaseClient.js
+++ b/frontend/src/lib/supabaseClient.js
@@ -241,7 +241,6 @@ export const mappingApi = {
     const { data, error } = await supabase.rpc('get_total_strategiques_count');
 
     if (error) {
-      console.error('❌ [getTotalStrategiquesCount] Query Error:', error);
       throw error;
     }
     return data;


### PR DESCRIPTION
## Summary
- cleanup: remove stray `console.error` in `getTotalStrategiquesCount`

## Testing
- `npm run lint` *(fails: Invalid option '--ext')*
- `npm run type-check` *(fails: command `tsc --noEmit` failed)*

------
https://chatgpt.com/codex/tasks/task_e_68808bc0986c832186e93859caf727f0