### PR TITLE
Implement search term debouncing

### DIFF
--- a/frontend/src/hooks/useDebounce.ts
+++ b/frontend/src/hooks/useDebounce.ts
@@ -1,0 +1,14 @@
+import { useEffect, useState } from 'react';
+
+export function useDebounce<T>(value: T, delay = 500): T {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(() => {
+    const handler = setTimeout(() => setDebouncedValue(value), delay);
+    return () => {
+      clearTimeout(handler);
+    };
+  }, [value, delay]);
+
+  return debouncedValue;
+}

--- a/frontend/src/pages/Mapping.tsx
+++ b/frontend/src/pages/Mapping.tsx
@@ -16,6 +16,7 @@ import { Button } from '../components/ui/Button';
 import { MappingModal } from '../components/mapping/MappingModal';
 import { toast } from 'sonner';
 import { mappingApi } from '../lib/supabaseClient';
+import { useDebounce } from '../hooks/useDebounce';
 import * as XLSX from 'xlsx';
 
 interface BrandMapping {
@@ -39,6 +40,7 @@ export const Mapping: React.FC = () => {
   const [loading, setLoading] = useState(true);
   const [uploadLoading, setUploadLoading] = useState(false);
   const [searchTerm, setSearchTerm] = useState('');
+  const debouncedSearchTerm = useDebounce(searchTerm, 500);
   const [selectedSegment, setSelectedSegment] = useState<string>('all');
   const [selectedMarque, setSelectedMarque] = useState<string>('all');
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -87,7 +89,7 @@ export const Mapping: React.FC = () => {
       const filters = {
         ...(selectedSegment !== 'all' && { segment: selectedSegment }),
         ...(selectedMarque !== 'all' && { marque: selectedMarque }),
-        ...(searchTerm && { cat_fab: searchTerm }),
+        ...(debouncedSearchTerm && { cat_fab: debouncedSearchTerm }),
         ...(selectedFsmega !== 'all' && { fsmega: parseInt(selectedFsmega) }),
         ...(selectedFsfam !== 'all' && { fsfam: parseInt(selectedFsfam) }),
         ...(selectedFssfa !== 'all' && { fssfa: parseInt(selectedFssfa) }),
@@ -128,7 +130,7 @@ export const Mapping: React.FC = () => {
 
   useEffect(() => {
     setCurrentPage(1); // Reset to first page when filters change
-  }, [selectedSegment, selectedMarque, searchTerm, itemsPerPage, selectedFsmega, selectedFsfam, selectedFssfa, selectedStrategiq]);
+  }, [selectedSegment, selectedMarque, debouncedSearchTerm, itemsPerPage, selectedFsmega, selectedFsfam, selectedFssfa, selectedStrategiq]);
 
   useEffect(() => {
     setSegmentSearch(selectedSegment === 'all' ? '' : selectedSegment);
@@ -140,7 +142,7 @@ export const Mapping: React.FC = () => {
 
   useEffect(() => {
     fetchData();
-  }, [selectedSegment, selectedMarque, searchTerm, currentPage, itemsPerPage, selectedFsmega, selectedFsfam, selectedFssfa, selectedStrategiq]);
+  }, [selectedSegment, selectedMarque, debouncedSearchTerm, currentPage, itemsPerPage, selectedFsmega, selectedFsfam, selectedFssfa, selectedStrategiq]);
 
   // Filter functions for autocomplete
   const getFilteredSegments = () => {

--- a/frontend/src/pages/mappingPage.tsx
+++ b/frontend/src/pages/mappingPage.tsx
@@ -15,6 +15,7 @@ import { Button } from '../components/ui/Button';
 import { MappingModal } from '../components/mapping/MappingModal';
 import { toast } from 'sonner';
 import { mappingApi } from '../lib/supabaseClient';
+import { useDebounce } from '../hooks/useDebounce';
 import * as XLSX from 'xlsx';
 
 interface BrandMapping {
@@ -37,6 +38,7 @@ export const MappingPage: React.FC = () => {
   const [loading, setLoading] = useState(true);
   const [uploadLoading, setUploadLoading] = useState(false);
   const [searchTerm, setSearchTerm] = useState('');
+  const debouncedSearchTerm = useDebounce(searchTerm, 500);
   const [selectedSegment, setSelectedSegment] = useState<string>('all');
   const [selectedMarque, setSelectedMarque] = useState<string>('all');
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -52,7 +54,7 @@ export const MappingPage: React.FC = () => {
       const filters = {
         ...(selectedSegment !== 'all' && { segment: selectedSegment }),
         ...(selectedMarque !== 'all' && { marque: selectedMarque }),
-        ...(searchTerm && { cat_fab: searchTerm })
+        ...(debouncedSearchTerm && { cat_fab: debouncedSearchTerm })
       };
       
       const [mappingsData, segmentsData, marquesData] = await Promise.all([
@@ -74,7 +76,7 @@ export const MappingPage: React.FC = () => {
 
   useEffect(() => {
     fetchData();
-  }, [selectedSegment, selectedMarque, searchTerm]);
+  }, [selectedSegment, selectedMarque, debouncedSearchTerm]);
 
   // Calculer CLASSIF_CIR automatiquement
   const calculateClassifCir = (fsmega: number, fsfam: number, fssfa: number): string => {


### PR DESCRIPTION
## Summary
- add a reusable `useDebounce` hook
- debounce search in Mapping page
- debounce search in the old MappingPage

## Testing
- `npm run lint` *(fails: Invalid option '--ext'...)*
- `npm run type-check` *(fails: several TS errors in sidebar.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68808bccefac83218b6c5b0f71f14c12