### PR TITLE
Implement paginated fetch for brand mappings

### DIFF
--- a/frontend/src/lib/supabaseClient.js
+++ b/frontend/src/lib/supabaseClient.js
@@ -236,13 +236,28 @@ export const mappingApi = {
 
   // Get all mappings without pagination for preview comparison
   async getAllBrandCategoryMappings() {
-    const { data, error } = await supabase
-      .from('brand_category_mappings')
-      .select('*')
-      .order('created_at', { ascending: false });
-    
-    if (error) throw error;
-    return data || [];
+    const batchSize = 1000;
+    let from = 0;
+    let allData = [];
+
+    while (true) {
+      const { data, error } = await supabase
+        .from('brand_category_mappings')
+        .select('*')
+        .order('created_at', { ascending: false })
+        .range(from, from + batchSize - 1);
+
+      if (error) throw error;
+      if (data) {
+        allData = allData.concat(data);
+      }
+
+      if (!data || data.length < batchSize) break;
+
+      from += batchSize;
+    }
+
+    return allData;
   },
 
   // Get total count of unique segments via RPC


### PR DESCRIPTION
## Summary
- retrieve brand-category mappings in batches to handle large datasets

## Testing
- `npm run lint` *(fails: Invalid option '--ext' using eslint.config.js)*
- `npm run type-check` *(fails: TypeScript errors in sidebar.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_6880d559fc1483219d34f931883d8ddf