### PR TITLE
Add delete policy for mapping history

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 cir_pricing
+
+## Supabase Policies
+
+* Admins can delete entries from `brand_mapping_history` thanks to RLS policy added in migrations.

--- a/supabase/migrations/20250723140309_allow_history_delete.sql
+++ b/supabase/migrations/20250723140309_allow_history_delete.sql
@@ -1,0 +1,25 @@
+/*
+  # Allow admin deletion of brand_mapping_history records
+
+  1. Ensure RLS is enabled
+    - `brand_mapping_history` table should have row level security enabled
+
+  2. Add delete policy for admins
+    - Only authenticated users with role 'admin' in profiles can delete
+*/
+
+-- Ensure RLS is enabled on brand_mapping_history
+ALTER TABLE IF EXISTS brand_mapping_history ENABLE ROW LEVEL SECURITY;
+
+-- Policy to allow admins to delete history records
+CREATE POLICY "Admins can delete mapping history"
+  ON brand_mapping_history
+  FOR DELETE
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM profiles
+      WHERE profiles.id = auth.uid()
+      AND profiles.role = 'admin'
+    )
+  );


### PR DESCRIPTION
## Summary
- enable RLS on `brand_mapping_history` and allow admin deletions
- document the new delete policy

## Testing
- `npm run lint` *(fails: Invalid option `--ext`)*
- `npm run type-check` *(fails: TS errors in sidebar.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_6880eafbfb888321b5790c52a12dc2ce