### PR TITLE
Create profile on sign-up

### DIFF
--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -79,20 +79,33 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     setLoading(true);
     
     try {
-      const { data, error } = await supabase.auth.signUp({
-        email,
-        password,
-        options: {
-          data: {
-            first_name: firstName,
-            last_name: lastName
-          }
+    const { data, error } = await supabase.auth.signUp({
+      email,
+      password,
+      options: {
+        data: {
+          first_name: firstName,
+          last_name: lastName
         }
+      }
+    });
+
+    if (error) {
+      throw error;
+    }
+
+    if (data?.user) {
+      const { error: insertError } = await supabase.from('profiles').insert({
+        id: data.user.id,
+        email: data.user.email,
+        first_name: firstName,
+        last_name: lastName
       });
 
-      if (error) {
-        throw error;
+      if (insertError) {
+        throw insertError;
       }
+    }
 
       // For sign up, we don't automatically set the user as they might need email confirmation
       setLoading(false);


### PR DESCRIPTION
## Summary
- add profile record when signing up a new user

## Testing
- `npm run lint` *(fails: Invalid option '--ext' due to ESLint CLI changes)*
- `npm run type-check` *(fails: TS errors in sidebar.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_6880ef459bf8832182c6196187a84245