### PR TITLE
Create profile when signup lacks session

### DIFF
--- a/supabase/functions/create-profile/index.ts
+++ b/supabase/functions/create-profile/index.ts
@@ -1,0 +1,36 @@
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+
+serve(async (req) => {
+  try {
+    const { id, email, first_name, last_name } = await req.json()
+
+    const supabase = createClient(
+      Deno.env.get('SUPABASE_URL')!,
+      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
+    )
+
+    const { error } = await supabase.from('profiles').insert({
+      id,
+      email,
+      first_name,
+      last_name
+    })
+
+    if (error) {
+      return new Response(JSON.stringify({ error: error.message }), {
+        status: 500,
+        headers: { 'Content-Type': 'application/json' }
+      })
+    }
+
+    return new Response(JSON.stringify({ success: true }), {
+      headers: { 'Content-Type': 'application/json' }
+    })
+  } catch (err) {
+    return new Response(JSON.stringify({ error: err.message }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' }
+    })
+  }
+})


### PR DESCRIPTION
## Summary
- call new `create-profile` edge function to add user profile when signup completes but no session is returned
- add `create-profile` edge function using service role

## Testing
- `npm run lint` *(fails: Invalid option '--ext')*
- `npm run type-check` *(fails: TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_6880f2c164b08321a02ad923832a33e5