### PR TITLE
fix: handle zero codes in classification import

### DIFF
--- a/frontend/src/lib/excelParser.ts
+++ b/frontend/src/lib/excelParser.ts
@@ -462,10 +462,10 @@ function parseCirClassificationDataRows(
       }
 
       // Vérifier les champs obligatoires
-      if (rowData.fsmega_code && rowData.fsmega_designation && 
-          rowData.fsfam_code !== undefined && rowData.fsfam_designation &&
-          rowData.fssfa_code !== undefined && rowData.fssfa_designation &&
-          rowData.combined_code && rowData.combined_designation) {
+      if (rowData.fsmega_code !== null && rowData.fsmega_code !== undefined && rowData.fsmega_designation &&
+          rowData.fsfam_code !== null && rowData.fsfam_code !== undefined && rowData.fsfam_designation &&
+          rowData.fssfa_code !== null && rowData.fssfa_code !== undefined && rowData.fssfa_designation &&
+          rowData.combined_code !== null && rowData.combined_code !== undefined && rowData.combined_designation) {
         
         data.push(rowData as CirClassificationOutput);
         validLines++;


### PR DESCRIPTION
## Summary
- ensure CIR classification import accepts code value 0 by checking explicit null/undefined

## Testing
- `node - <<'NODE'
function parseCirClassificationDataRows(rows, headers, columnMapping) {
  const data = [];
  for (let i = 0; i < rows.length; i++) {
    const row = rows[i];
    const rowData = {};
    for (let j = 0; j < headers.length; j++) {
      const header = headers[j];
      const fieldName = columnMapping[header];
      if (fieldName) {
        let value = row[j];
        if (typeof value === 'string') {
          value = value.trim();
          if (value === '') value = null;
        }
        if (['fsmega_code','fsfam_code','fssfa_code'].includes(fieldName) && value !== null) {
          const numValue = Number(value);
          if (!isNaN(numValue)) {
            value = Math.floor(numValue);
          }
        }
        rowData[fieldName] = value;
      }
    }
    if (rowData.fsmega_code !== null && rowData.fsmega_code !== undefined && rowData.fsmega_designation &&
        rowData.fsfam_code !== null && rowData.fsfam_code !== undefined && rowData.fsfam_designation &&
        rowData.fssfa_code !== null && rowData.fssfa_code !== undefined && rowData.fssfa_designation &&
        rowData.combined_code !== null && rowData.combined_code !== undefined && rowData.combined_designation) {
      data.push(rowData);
    }
  }
  return data;
}
const headers=['FSMEGA Code','FSMEGA Designation','FSFAM Code','FSFAM Designation','FSSFA Code','FSSFA Designation','Code 1&2&3','Designation 1&2&3'];
const columnMapping={
  'FSMEGA Code':'fsmega_code',
  'FSMEGA Designation':'fsmega_designation',
  'FSFAM Code':'fsfam_code',
  'FSFAM Designation':'fsfam_designation',
  'FSSFA Code':'fssfa_code',
  'FSSFA Designation':'fssfa_designation',
  'Code 1&2&3':'combined_code',
  'Designation 1&2&3':'combined_designation'
};
const rows=[[0,'Mega zero',0,'Fam zero',0,'Sfa zero',0,'Combined zero']];
const result=parseCirClassificationDataRows(rows,headers,columnMapping);
console.log(result);
NODE`
- `npm test --prefix frontend`
- `npm run lint --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_68a5a675c8788321969d74507560e422