### PR TITLE
Ensure classification codes are not null

### DIFF
--- a/frontend/src/lib/excelParser.ts
+++ b/frontend/src/lib/excelParser.ts
@@ -462,9 +462,9 @@ function parseCirClassificationDataRows(
       }
 
       // Vérifier les champs obligatoires
-      if (rowData.fsmega_code && rowData.fsmega_designation && 
-          rowData.fsfam_code !== undefined && rowData.fsfam_designation &&
-          rowData.fssfa_code !== undefined && rowData.fssfa_designation &&
+      if (rowData.fsmega_code && rowData.fsmega_designation &&
+          rowData.fsfam_code != null && rowData.fsfam_designation &&
+          rowData.fssfa_code != null && rowData.fssfa_designation &&
           rowData.combined_code && rowData.combined_designation) {
         
         data.push(rowData as CirClassificationOutput);


### PR DESCRIPTION
## Summary
- Require `fsfam_code` and `fssfa_code` to be neither null nor undefined during CIR classification parsing

## Testing
- `npm run lint` *(fails: numerous lint errors)*
- `npm run type-check` *(fails: TypeScript errors in unrelated files)*
- `node <script>` to parse sample CIR classification rows with null codes

------
https://chatgpt.com/codex/tasks/task_e_68a5a676b7a88321b5089bf037e29f01